### PR TITLE
Permit no migrations to be in common

### DIFF
--- a/common_migration/find_common_migrations.py
+++ b/common_migration/find_common_migrations.py
@@ -191,7 +191,7 @@ def _read_migration_tuples(
             if isinstance(node, ast.Assign)
             and len(node.targets) == 1
             and isinstance(node.targets[0], ast.Name)
-            and cast(ast.Name, node.targets[0]).id == attribute_name
+            and node.targets[0].id == attribute_name
             and isinstance(node.value, ast.List)
         ),
         None
@@ -200,7 +200,7 @@ def _read_migration_tuples(
     if ast_list is None:
         return []
 
-    migration_names = []
+    migration_names: list[tuple[str, str]] = []
 
     for element in ast_list.elts:
         if not isinstance(element, ast.Tuple):
@@ -442,10 +442,8 @@ def main():
 
     reverse_node = find_reverse_migration_node(old_node, new_node, app_name)
 
-    if reverse_node is None:
-        sys.exit('There are no migrations in common!')
-
-    print(f'{reverse_node.name}')
+    if reverse_node is not None:
+        print(f'{reverse_node.name}')
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/common_migration/tests/test_find_common_migrations.py
+++ b/common_migration/tests/test_find_common_migrations.py
@@ -467,10 +467,10 @@ class FindMigrationScriptTestCase(TestCase):
 
         assert str(ctx.exception) == 'Invalid app_name: wat'
 
-    def test_script_fails_when_all_migrations_are_replaced(self):
+    def test_script_prints_nothing_when_all_migrations_are_replaced(self):
         sys.argv[-1] = os.path.join(TEST_MIGRATION_FILES_DIR, 'totally_replaced')
 
-        with self.assertRaises(SystemExit) as ctx:
+        with mock.patch('builtins.print') as print_mock:
             main()
 
-        assert str(ctx.exception) == 'There are no migrations in common!'
+        print_mock.assert_not_called()


### PR DESCRIPTION
When migrations are squashed, all migrations from the previous commit can be replaced, so we need to just skip reverting migrations in that case.